### PR TITLE
uwsgi server implementation in docker-compose.yaml

### DIFF
--- a/bin/run-uwsgi.sh
+++ b/bin/run-uwsgi.sh
@@ -18,6 +18,8 @@ exec uwsgi \
     --master --pidfile=/tmp/project-master.pid \
     --log-x-forwarded-for \
     --log-format-strftime \
+    --uid=1000 \
+    --gid=2000 \
     --http-socket=:$PORT \
     --cheaper-algo=busyness \
     --cheaper=$MIN_WORKERS \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,15 @@ services:
   web:
     build: .
     user: root # Allows for usage of ipdb, apt, etc in dev
-    command: ./manage.py runserver 0.0.0.0:8000
+    entrypoint: ["./bin/start.sh"]
     depends_on: *default-depends_on
     volumes: *default-volumes
     ports:
       - "8000:8000"
-    environment: *default-environment
+    environment:
+      <<: *default-environment
+      DJANGO_SETTINGS_MODULE: "glitchtip.settings"
+      PORT: "8000"
   worker:
     build: .
     user: root


### PR DESCRIPTION
Hi @pepedocs , I've modifed the docker-compose.yaml to use the `./bin/start.sh` for the backend which ensures that uwsgi is running. I've validated this by checking the executable that is running in my local setup
![Screenshot_20220614_011453](https://user-images.githubusercontent.com/16438494/173432636-75b53692-a3ee-4eea-8085-5c2625e34576.png)
logs from docker-compose
```bash
glitchtip-backend-web-1       | Running uwsgi with INITIAL_WORKERS: 6, MIN_WORKERS: 4, MAX_WORKERS: 8, OVERLOAD_TIME: 30, THREADS: 1
glitchtip-backend-web-1       | *** Starting uWSGI 2.0.20 (64bit) on [Mon Jun 13 19:42:07 2022] ***
glitchtip-backend-web-1       | compiled with version: 10.2.1 20210110 on 13 June 2022 04:51:35
glitchtip-backend-web-1       | os: Linux-5.17.12-300.fc36.x86_64 #1 SMP PREEMPT Mon May 30 16:56:53 UTC 2022
glitchtip-backend-web-1       | nodename: f7222c2f1086
glitchtip-backend-web-1       | machine: x86_64
glitchtip-backend-web-1       | clock source: unix
glitchtip-backend-web-1       | pcre jit disabled
glitchtip-backend-web-1       | detected number of CPU cores: 12
glitchtip-backend-web-1       | current working directory: /code
glitchtip-backend-web-1       | writing pidfile to /tmp/project-master.pid
glitchtip-backend-web-1       | detected binary path: /usr/local/bin/uwsgi
glitchtip-backend-web-1       | uWSGI running as root, you can use --uid/--gid/--chroot options
glitchtip-backend-web-1       | setgid() to 2000
glitchtip-backend-web-1       | setuid() to 1000
glitchtip-backend-web-1       | your memory page size is 4096 bytes
glitchtip-backend-web-1       |  *** WARNING: you have enabled harakiri without post buffering. Slow upload could be rejected on post-unbuffered webservers *** 
glitchtip-backend-web-1       | detected max file descriptor number: 1073741816
glitchtip-backend-web-1       | lock engine: pthread robust mutexes
glitchtip-backend-web-1       | thunder lock: disabled (you can enable it with --thunder-lock)
glitchtip-backend-web-1       | [busyness] settings: min=25%, max=50%, overload=30, multiplier=20, respawn penalty=2
glitchtip-backend-web-1       | [busyness] backlog alert is set to 33 request(s), step is 1
glitchtip-backend-web-1       | [busyness] backlog non-zero alert is set to 60 second(s)
glitchtip-backend-web-1       | uwsgi socket 0 bound to TCP address :8000 fd 3
glitchtip-backend-web-1       | Python version: 3.10.5 (main, Jun  7 2022, 18:49:47) [GCC 10.2.1 20210110]
glitchtip-backend-web-1       | Python main interpreter initialized at 0x55b1f2811a40
glitchtip-backend-web-1       | python threads support enabled
glitchtip-backend-web-1       | your server socket listen backlog is limited to 128 connections
glitchtip-backend-web-1       | your mercy for graceful operations on workers is 60 seconds
glitchtip-backend-web-1       | mapped 656280 bytes (640 KB) for 8 cores
glitchtip-backend-web-1       | *** Operational MODE: preforking ***
```

I've created a sample user from UI and tested out the error to ensure that glitchtip is working fine
![Screenshot_20220614_011733](https://user-images.githubusercontent.com/16438494/173433069-628a7c93-ca9f-4a7e-a23f-90bf8901bfea.png)

